### PR TITLE
fix: use HTTPS for IP geolocation and disable cleartext traffic

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
     <application
         android:name=".ClipSyncApp"
         android:allowBackup="true"
-        android:usesCleartextTraffic="true"
+        android:usesCleartextTraffic="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/android/app/src/main/java/com/bunty/clipsync/LocationHelper.kt
+++ b/android/app/src/main/java/com/bunty/clipsync/LocationHelper.kt
@@ -20,10 +20,11 @@ import java.io.InputStreamReader
  * presenting a region picker to the user, LocationHelper resolves the question silently by
  * mapping the device's public IP address to a country code.
  *
- * **How it works:** An HTTP GET is sent to [ip-api.com](http://ip-api.com), a free and
- * widely-used IP intelligence service. The JSON response is parsed and only the
- * `countryCode` field (ISO 3166-1 alpha-2, e.g. `"IN"` or `"US"`) is retained. No
- * other fields from the response are read, stored, or transmitted.
+ * **How it works:** An HTTPS GET is sent to [ip-api.com](https://ip-api.com), a free and
+ * widely-used IP intelligence service, with [api.country.is](https://api.country.is) as
+ * a fallback. The JSON response is parsed and only the country code field (ISO 3166-1
+ * alpha-2, e.g. `"IN"` or `"US"`) is retained. No other fields from the response are
+ * read, stored, or transmitted.
  *
  * **Threading:** The network call is a suspending function that switches to [Dispatchers.IO],
  * so it never blocks the main thread. Both the TCP connection and the response-read are
@@ -34,53 +35,74 @@ object LocationHelper {
     /**
      * Resolves the ISO 3166-1 alpha-2 country code for the device's current public IP address.
      *
-     * Execution steps:
-     *  1. Suspends and resumes on [Dispatchers.IO] to keep blocking I/O off the main thread.
-     *  2. Opens an HTTP GET connection to `http://ip-api.com/json/` with 5-second timeouts
-     *     on both the TCP connect and the response read phases.
-     *  3. On HTTP 200, reads the full response body into a [StringBuilder], parses it as
-     *     JSON, and returns the value of the `countryCode` field.
-     *  4. On any non-200 HTTP status, returns `null`.
-     *  5. On any exception (network error, JSON parse error, timeout), logs the error
-     *     via [android.util.Log] and returns `null`.
-     *
-     * Callers should treat a `null` return as "region unknown" and fall back to a sensible
-     * default (typically India, the primary Firebase project region).
+     * Tries `https://ip-api.com/json/` first, then falls back to `https://api.country.is`.
+     * Both requests use HTTPS and 5-second timeouts. Runs on [Dispatchers.IO].
      *
      * @return A two-letter country code such as `"IN"`, `"US"`, or `"DE"` on success,
-     *         or `null` if the lookup fails for any reason.
+     *         or `null` if both lookups fail.
      */
     suspend fun detectCountryCode(): String? {
         return withContext(Dispatchers.IO) {
-            try {
-                val url = URL("http://ip-api.com/json/")
-                val connection = url.openConnection() as HttpURLConnection
-                connection.requestMethod  = "GET"
-                connection.connectTimeout = 5000  // 5-second connection timeout
-                connection.readTimeout    = 5000  // 5-second read timeout
+            // Try primary endpoint first, fall back to api.country.is on failure
+            detectFromIpApi() ?: detectFromCountryIs()
+        }
+    }
 
-                if (connection.responseCode == 200) {
-                    // Stream the response body line-by-line to handle arbitrarily sized payloads.
-                    val reader   = BufferedReader(InputStreamReader(connection.inputStream))
-                    val response = StringBuilder()
-                    var line: String?
-                    while (reader.readLine().also { line = it } != null) {
-                        response.append(line)
-                    }
-                    reader.close()
-                    connection.disconnect()
+    private fun detectFromIpApi(): String? {
+        return try {
+            val url = URL("https://ip-api.com/json/")
+            val connection = url.openConnection() as HttpURLConnection
+            connection.requestMethod  = "GET"
+            connection.connectTimeout = 5000
+            connection.readTimeout    = 5000
 
-                    // Parse the JSON and extract only the countryCode field; all other
-                    // fields returned by ip-api.com (city, ISP, lat/lon, etc.) are discarded.
-                    val json = JSONObject(response.toString())
-                    json.optString("countryCode", "")
-                } else {
-                    null
+            if (connection.responseCode == 200) {
+                val reader   = BufferedReader(InputStreamReader(connection.inputStream))
+                val response = StringBuilder()
+                var line: String?
+                while (reader.readLine().also { line = it } != null) {
+                    response.append(line)
                 }
-            } catch (e: Exception) {
-                Log.e("LocationHelper", "Error detecting location", e)
+                reader.close()
+                connection.disconnect()
+
+                val json = JSONObject(response.toString())
+                json.optString("countryCode", "").ifEmpty { null }
+            } else {
                 null
             }
+        } catch (e: Exception) {
+            Log.e("LocationHelper", "Error detecting location via ip-api", e)
+            null
+        }
+    }
+
+    private fun detectFromCountryIs(): String? {
+        return try {
+            val url = URL("https://api.country.is")
+            val connection = url.openConnection() as HttpURLConnection
+            connection.requestMethod  = "GET"
+            connection.connectTimeout = 5000
+            connection.readTimeout    = 5000
+
+            if (connection.responseCode == 200) {
+                val reader   = BufferedReader(InputStreamReader(connection.inputStream))
+                val response = StringBuilder()
+                var line: String?
+                while (reader.readLine().also { line = it } != null) {
+                    response.append(line)
+                }
+                reader.close()
+                connection.disconnect()
+
+                val json = JSONObject(response.toString())
+                json.optString("country", "").ifEmpty { null }
+            } else {
+                null
+            }
+        } catch (e: Exception) {
+            Log.e("LocationHelper", "Error detecting location via country.is", e)
+            null
         }
     }
 }


### PR DESCRIPTION
## Summary
- Switch Android `LocationHelper` from `http://ip-api.com/json/` to `https://ip-api.com/json/`, matching the macOS implementation
- Add `https://api.country.is` as a fallback endpoint (also matching macOS)
- Set `android:usesCleartextTraffic="false"` in AndroidManifest.xml to block all cleartext HTTP app-wide

## Test plan
- [ ] Verify region detection still works on Android (country code resolved correctly)
- [ ] Verify fallback to api.country.is works when ip-api.com is unreachable
- [ ] Verify no other app functionality is broken by disabling cleartext traffic

Fixes #9

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)