### PR TITLE
fix: restrict accessibility service to least-privilege permissions

### DIFF
--- a/android/app/src/main/res/xml/accessibility_service_config.xml
+++ b/android/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,9 +1,9 @@
 <accessibility-service
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:description="@string/accessibility_service_description"
-    android:accessibilityEventTypes="typeViewTextSelectionChanged|typeViewClicked|typeNotificationStateChanged|typeWindowStateChanged|typeWindowContentChanged|typeViewFocused"
+    android:accessibilityEventTypes="typeViewClicked|typeNotificationStateChanged|typeWindowStateChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
-    android:accessibilityFlags="flagIncludeNotImportantViews|flagRetrieveInteractiveWindows|flagReportViewIds"
+    android:accessibilityFlags="flagReportViewIds"
     android:canRetrieveWindowContent="true"
     android:settingsActivity="com.bunty.clipsync.MainActivity"
     android:notificationTimeout="100" />


### PR DESCRIPTION
## Summary
- Remove unused accessibility event types (`typeViewTextSelectionChanged`, `typeWindowContentChanged`, `typeViewFocused`) that the code never handles
- Remove unnecessary flags (`flagIncludeNotImportantViews`, `flagRetrieveInteractiveWindows`) that widen the attack surface without being used
- Retain `flagReportViewIds` (needed by `dfsFindCopy` for `node.viewIdResourceName`) and `canRetrieveWindowContent="true"` (needed for `event.source` and DFS child traversal)

Closes #8

## Test plan
- [ ] Enable the accessibility service on a device/emulator
- [ ] Copy text in various apps — verify clipboard sync still works
- [ ] Verify toast-based "Copied" detection still triggers
- [ ] Verify DFS-based copy detection still works (apps without standard ACTION_COPY)

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)