### PR TITLE
fix: store encryption key in macOS Keychain instead of UserDefaults

### DIFF
--- a/mac/ClipSync/ClipboardManager.swift
+++ b/mac/ClipSync/ClipboardManager.swift
@@ -4,7 +4,7 @@
 // ClipboardManager.swift
 // Singleton that polls NSPasteboard every 300 ms for changes, encrypts and uploads
 // content to Firestore, and listens for incoming clipboard items from Android.
-// Uses AES-GCM with a shared key stored in UserDefaults.
+// Uses AES-GCM with a shared key stored in the macOS Keychain.
 
 import Foundation
 import AppKit
@@ -40,7 +40,7 @@ class ClipboardManager: ObservableObject {
     private var clipboardListener: ListenerRegistration?
 
     private var sharedSecretHex: String {
-        return UserDefaults.standard.string(forKey: "encryption_key") ?? Secrets.fallbackEncryptionKey
+        return KeychainHelper.getEncryptionKey() ?? Secrets.fallbackEncryptionKey
     }
 
     private var isListenerActive = false

--- a/mac/ClipSync/KeychainHelper.swift
+++ b/mac/ClipSync/KeychainHelper.swift
@@ -1,0 +1,86 @@
+// KeychainHelper.swift
+// Provides secure storage for the AES-256 encryption key using the macOS Keychain
+// instead of UserDefaults. Includes one-time migration from UserDefaults.
+
+import Foundation
+import Security
+
+enum KeychainHelper {
+    private static let service = "com.clipsync.encryption"
+    private static let account = "encryption_key"
+
+    // MARK: - Public API
+
+    /// Retrieves the encryption key, migrating from UserDefaults on first access if needed.
+    static func getEncryptionKey() -> String? {
+        if let key = readFromKeychain() {
+            return key
+        }
+
+        // Migration: move key from UserDefaults to Keychain
+        if let legacyKey = UserDefaults.standard.string(forKey: "encryption_key") {
+            if saveToKeychain(legacyKey) {
+                UserDefaults.standard.removeObject(forKey: "encryption_key")
+            }
+            return legacyKey
+        }
+
+        return nil
+    }
+
+    /// Stores a new encryption key in the Keychain.
+    @discardableResult
+    static func setEncryptionKey(_ key: String) -> Bool {
+        // Delete any existing key first, then save
+        deleteFromKeychain()
+        return saveToKeychain(key)
+    }
+
+    // MARK: - Keychain Operations
+
+    private static func readFromKeychain() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let key = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        return key
+    }
+
+    private static func saveToKeychain(_ key: String) -> Bool {
+        guard let data = key.data(using: .utf8) else { return false }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
+        ]
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+
+    private static func deleteFromKeychain() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/mac/ClipSync/OTPNotificationManager.swift
+++ b/mac/ClipSync/OTPNotificationManager.swift
@@ -33,7 +33,7 @@ class OTPNotificationManager: ObservableObject {
 
 
     private var sharedSecretHex: String {
-        return UserDefaults.standard.string(forKey: "encryption_key") ?? Secrets.fallbackEncryptionKey
+        return KeychainHelper.getEncryptionKey() ?? Secrets.fallbackEncryptionKey
     }
 
 

--- a/mac/ClipSync/QRCodeGenerator.swift
+++ b/mac/ClipSync/QRCodeGenerator.swift
@@ -21,11 +21,11 @@ class QRCodeGenerator: ObservableObject {
 
     private var sharedSecretHex: String {
         get {
-            if let savedKey = UserDefaults.standard.string(forKey: "encryption_key") {
+            if let savedKey = KeychainHelper.getEncryptionKey() {
                 return savedKey
             }
             let newKey = generateRandomHexKey()
-            UserDefaults.standard.set(newKey, forKey: "encryption_key")
+            KeychainHelper.setEncryptionKey(newKey)
             return newKey
         }
     }


### PR DESCRIPTION
## Summary
- Migrates AES-256 encryption key storage from `UserDefaults` (plaintext plist) to the macOS Keychain via `SecItemAdd`/`SecItemCopyMatching`
- Adds `KeychainHelper.swift` with automatic migration: on first access, existing keys are moved from UserDefaults to Keychain and deleted from UserDefaults
- Updates all three consumers (`ClipboardManager`, `OTPNotificationManager`, `QRCodeGenerator`) to use the new helper

Fixes #11

## Test plan
- [ ] Fresh install: verify a new encryption key is generated and stored in Keychain (not UserDefaults)
- [ ] Upgrade from existing install: verify the key migrates from UserDefaults to Keychain on first launch
- [ ] After migration, confirm `encryption_key` is no longer present in UserDefaults plist
- [ ] Verify clipboard sync (Mac→Android and Android→Mac) still works with the Keychain-stored key
- [ ] Verify OTP notifications still decrypt correctly

> [!Note]
> Responses generated with Claude

🤖 Generated with [Claude Code](https://claude.ai/code)