### PR TITLE
fix: validate FCM push notification URLs against domain allowlist

### DIFF
--- a/android/app/src/main/java/com/bunty/clipsync/Homescreen.kt
+++ b/android/app/src/main/java/com/bunty/clipsync/Homescreen.kt
@@ -59,6 +59,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import com.bunty.clipsync.R
@@ -213,14 +215,27 @@ fun Homescreen(
     // "Later" option that simply dismisses and clears the stored update info.
     // =========================================================================
     if (showUpdateDialog && updateInfo != null) {
+        val isUpdateUrlTrusted = UrlAllowlistManager.isUrlTrusted(context, updateInfo!!.downloadUrl)
+
         AlertDialog(
-            onDismissRequest = { 
+            onDismissRequest = {
                 showUpdateDialog = false
                 UpdateNotificationManager.clearPendingUpdate(context)
             },
-            title = { Text(text = "Update Available 🚀") },
+            title = {
+                Text(text = if (isUpdateUrlTrusted) "Update Available 🚀" else "⚠️ Update from untrusted source")
+            },
             text = {
                 Column {
+                    if (!isUpdateUrlTrusted) {
+                        Text(
+                            text = "Warning: This update links to an unrecognised domain (${UrlAllowlistManager.extractHost(updateInfo!!.downloadUrl)}). Proceed only if you trust this source.",
+                            color = Color(0xFFFF9500),
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                    }
                     Text("Version ${updateInfo!!.version} is now available!")
                     Spacer(modifier = Modifier.height(12.dp))
                     Text(
@@ -240,12 +255,12 @@ fun Homescreen(
                         UpdateNotificationManager.clearPendingUpdate(context)
                     }
                 ) {
-                    Text("Download")
+                    Text(if (isUpdateUrlTrusted) "Download" else "Open Anyway")
                 }
             },
             dismissButton = {
                 TextButton(
-                    onClick = { 
+                    onClick = {
                         showUpdateDialog = false
                         UpdateNotificationManager.clearPendingUpdate(context)
                     }
@@ -471,6 +486,17 @@ fun Homescreen(
                             }
                         }
                     }
+
+                    // =============================================================
+                    // TRUSTED DOMAINS SECTION
+                    // Displays the URL domain allowlist used to validate URLs from
+                    // FCM push notifications. Default domains cannot be removed.
+                    // Users can add or remove custom trusted domains.
+                    // =============================================================
+                    TrustedDomainsSection(
+                        fontFamily = robotoFontFamily,
+                        scale = scale
+                    )
 
                     // =============================================================
                     // SYSTEM STATUS SECTION
@@ -959,6 +985,201 @@ fun ActionButton(text: String, icon: ImageVector, backgroundColor: Color, fontFa
                 fontWeight = FontWeight.SemiBold,
                 fontSize = (17 * scale).coerceIn(15f, 17f).sp,
                 color = backgroundColor
+            )
+        }
+    }
+}
+
+
+/**
+ * Composable section that displays and manages the trusted URL domain allowlist.
+ *
+ * Shows default domains (non-removable) and user-added domains (removable via tap).
+ * Includes a text field for adding new custom domains. Domains are displayed as
+ * chip-like pills — default domains in blue, user domains in green with an "×" to remove.
+ *
+ * @param fontFamily The Roboto [FontFamily] for consistent typography.
+ * @param scale Responsive scale factor derived from screen dimensions.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun TrustedDomainsSection(fontFamily: FontFamily, scale: Float = 1f) {
+    val context = LocalContext.current
+    var userDomains by remember { mutableStateOf(UrlAllowlistManager.getUserDomains(context)) }
+    var newDomain by remember { mutableStateOf("") }
+    var showAddField by remember { mutableStateOf(false) }
+
+    Column {
+        SectionHeader(text = "Trusted Domains", fontFamily = fontFamily, scale = scale)
+
+        InnerWhiteCard(scale = scale) {
+            Column(modifier = Modifier.padding((20 * scale).dp)) {
+                Text(
+                    text = "URLs from push notifications are checked against these domains. Untrusted URLs show a warning.",
+                    fontFamily = fontFamily,
+                    fontSize = (13 * scale).coerceIn(11f, 13f).sp,
+                    color = Color(0xFF3C3C43).copy(alpha = 0.6f),
+                    lineHeight = (18 * scale).coerceIn(14f, 18f).sp
+                )
+
+                Spacer(modifier = Modifier.height((16 * scale).dp))
+
+                // Display default (built-in) domains as non-removable chips.
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy((8 * scale).dp),
+                    verticalArrangement = Arrangement.spacedBy((8 * scale).dp)
+                ) {
+                    UrlAllowlistManager.DEFAULT_DOMAINS.sorted().forEach { domain ->
+                        DomainChip(
+                            domain = domain,
+                            isDefault = true,
+                            fontFamily = fontFamily,
+                            scale = scale,
+                            onRemove = {}
+                        )
+                    }
+                    userDomains.sorted().forEach { domain ->
+                        DomainChip(
+                            domain = domain,
+                            isDefault = false,
+                            fontFamily = fontFamily,
+                            scale = scale,
+                            onRemove = {
+                                UrlAllowlistManager.removeUserDomain(context, domain)
+                                userDomains = UrlAllowlistManager.getUserDomains(context)
+                            }
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height((16 * scale).dp))
+
+                if (showAddField) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        androidx.compose.material3.OutlinedTextField(
+                            value = newDomain,
+                            onValueChange = { newDomain = it.lowercase().trim() },
+                            placeholder = {
+                                Text(
+                                    "example.com",
+                                    fontSize = (14 * scale).coerceIn(12f, 14f).sp
+                                )
+                            },
+                            singleLine = true,
+                            modifier = Modifier.weight(1f),
+                            textStyle = androidx.compose.ui.text.TextStyle(
+                                fontSize = (14 * scale).coerceIn(12f, 14f).sp,
+                                fontFamily = fontFamily
+                            )
+                        )
+                        Spacer(modifier = Modifier.width((8 * scale).dp))
+                        Box(
+                            modifier = Modifier
+                                .clip(RoundedCornerShape((16 * scale).dp))
+                                .background(Color(0xFF34C759))
+                                .clickable(
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    indication = null
+                                ) {
+                                    if (newDomain.isNotBlank() && newDomain.contains(".")) {
+                                        UrlAllowlistManager.addUserDomain(context, newDomain)
+                                        userDomains = UrlAllowlistManager.getUserDomains(context)
+                                        newDomain = ""
+                                        showAddField = false
+                                    }
+                                }
+                                .padding(horizontal = (14 * scale).dp, vertical = (8 * scale).dp)
+                        ) {
+                            Text(
+                                text = "Add",
+                                fontFamily = fontFamily,
+                                fontWeight = FontWeight.Bold,
+                                fontSize = (14 * scale).coerceIn(12f, 14f).sp,
+                                color = Color.White
+                            )
+                        }
+                    }
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape((16 * scale).dp))
+                            .background(Color(0xFF007AFF).copy(alpha = 0.1f))
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null
+                            ) { showAddField = true }
+                            .padding(horizontal = (14 * scale).dp, vertical = (8 * scale).dp)
+                    ) {
+                        Text(
+                            text = "+ Add Domain",
+                            fontFamily = fontFamily,
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = (14 * scale).coerceIn(12f, 14f).sp,
+                            color = Color(0xFF007AFF)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+/**
+ * A chip-style pill displaying a single domain name.
+ *
+ * Default domains are shown in blue and cannot be removed. User-added domains are
+ * shown in green with an "×" suffix that triggers removal on tap.
+ *
+ * @param domain The domain string to display.
+ * @param isDefault True if this is a built-in default domain (non-removable).
+ * @param fontFamily Font family for the label text.
+ * @param scale Responsive scale factor.
+ * @param onRemove Callback invoked when a user domain's "×" is tapped.
+ */
+@Composable
+fun DomainChip(
+    domain: String,
+    isDefault: Boolean,
+    fontFamily: FontFamily,
+    scale: Float = 1f,
+    onRemove: () -> Unit
+) {
+    val chipColor = if (isDefault) Color(0xFF007AFF) else Color(0xFF34C759)
+
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape((14 * scale).dp))
+            .background(chipColor.copy(alpha = 0.1f))
+            .then(
+                if (!isDefault) {
+                    Modifier.clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null
+                    ) { onRemove() }
+                } else Modifier
+            )
+            .padding(horizontal = (12 * scale).dp, vertical = (6 * scale).dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = domain,
+            fontFamily = fontFamily,
+            fontWeight = FontWeight.Medium,
+            fontSize = (13 * scale).coerceIn(11f, 13f).sp,
+            color = chipColor
+        )
+        if (!isDefault) {
+            Spacer(modifier = Modifier.width((6 * scale).dp))
+            Text(
+                text = "×",
+                fontFamily = fontFamily,
+                fontWeight = FontWeight.Bold,
+                fontSize = (14 * scale).coerceIn(12f, 14f).sp,
+                color = chipColor.copy(alpha = 0.7f)
             )
         }
     }

--- a/android/app/src/main/java/com/bunty/clipsync/MyFirebaseMessagingService.kt
+++ b/android/app/src/main/java/com/bunty/clipsync/MyFirebaseMessagingService.kt
@@ -98,6 +98,9 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
                     val downloadUrl = remoteMessage.data["downloadUrl"] ?: ""
                     val releaseNotes = remoteMessage.data["releaseNotes"] ?: "New update available!"
 
+                    // Validate the download URL against the trusted-domain allowlist.
+                    val isTrusted = UrlAllowlistManager.isUrlTrusted(applicationContext, downloadUrl)
+
                     // Persist update details so MainActivity can present a download dialog even
                     // if the user dismissed or never saw the notification.
                     UpdateNotificationManager.savePendingUpdate(
@@ -108,11 +111,13 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
                     )
 
                     // Post an immediate status-bar notification so the user is informed right away.
+                    // If the URL is untrusted, the notification will include a warning.
                     UpdateNotificationManager.showUpdateNotification(
                         applicationContext,
                         version,
                         releaseNotes,
-                        downloadUrl
+                        downloadUrl,
+                        isTrusted
                     )
                 }
 
@@ -123,6 +128,9 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
                     val actionLabel = remoteMessage.data["actionLabel"] ?: "Open"
                     val actionUrl   = remoteMessage.data["actionUrl"]   ?: ""
 
+                    // Validate the action URL against the trusted-domain allowlist.
+                    val isTrusted = UrlAllowlistManager.isUrlTrusted(applicationContext, actionUrl)
+
                     // Guard against an empty body to prevent a content-free notification appearing
                     // in the shade, which would confuse or annoy the user.
                     if (body.isNotEmpty()) {
@@ -131,7 +139,8 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
                             title,
                             body,
                             actionLabel,
-                            actionUrl
+                            actionUrl,
+                            isTrusted
                         )
                     }
                 }

--- a/android/app/src/main/java/com/bunty/clipsync/UpdateNotificationManager.kt
+++ b/android/app/src/main/java/com/bunty/clipsync/UpdateNotificationManager.kt
@@ -77,16 +77,21 @@ object UpdateNotificationManager {
      * The expanded (BigText) style shows up to 150 characters of [releaseNotes] so the
      * user can quickly decide whether to update without leaving the notification shade.
      *
+     * When [isTrusted] is false, the notification title and body are modified to warn
+     * the user that the download URL comes from an unrecognised domain.
+     *
      * @param context      Application context required to build intents and post the notification.
      * @param version      Human-readable new version string, e.g. `"1.2.0"`.
      * @param releaseNotes Short summary of what changed; truncated to 150 chars in the UI.
      * @param downloadUrl  Direct URL to open on tap; falls back to [GITHUB_RELEASES_URL] if blank.
+     * @param isTrusted    Whether the [downloadUrl] passed the domain allowlist check.
      */
     fun showUpdateNotification(
         context: Context,
         version: String,
         releaseNotes: String,
-        downloadUrl: String = GITHUB_RELEASES_URL
+        downloadUrl: String = GITHUB_RELEASES_URL,
+        isTrusted: Boolean = true
     ) {
         createNotificationChannel(context)
 
@@ -118,20 +123,36 @@ object UpdateNotificationManager {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
+        // When the URL is untrusted, modify the notification to warn the user so they
+        // can make an informed decision before tapping through to an unknown domain.
+        val title: String
+        val shortText: String
+        val expandedText: String
+
+        if (isTrusted) {
+            title = "ClipSync Update Available 🚀"
+            shortText = "Version $version is ready to download!"
+            expandedText = "Version $version is ready!\n\n${releaseNotes.take(150)}"
+        } else {
+            val host = UrlAllowlistManager.extractHost(resolvedUrl)
+            title = "⚠️ Update from untrusted source"
+            shortText = "Version $version links to $host (not in your trusted domains)"
+            expandedText = "⚠️ Version $version links to an untrusted domain: $host\n\n" +
+                "This URL was not recognised as a trusted source. " +
+                "Proceed only if you trust this domain.\n\n${releaseNotes.take(100)}"
+        }
+
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_launcher_foreground)
-            .setContentTitle("ClipSync Update Available 🚀")
-            .setContentText("Version $version is ready to download!")
-            .setStyle(
-                NotificationCompat.BigTextStyle()
-                    .bigText("Version $version is ready!\n\n${releaseNotes.take(150)}")
-            )
+            .setContentTitle(title)
+            .setContentText(shortText)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(expandedText))
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setAutoCancel(true)
             .setContentIntent(contentPendingIntent)
             .addAction(
                 R.drawable.ic_launcher_foreground,
-                "View on GitHub",
+                if (isTrusted) "View on GitHub" else "Open Anyway",
                 githubActionPendingIntent
             )
             .addAction(
@@ -169,13 +190,15 @@ object UpdateNotificationManager {
      * @param actionLabel Text label for the primary action button, e.g. `"Give Feedback"`.
      * @param actionUrl   URL to open when the body or action button is tapped. Pass an empty
      *                    string to open [MainActivity] instead of a browser URL.
+     * @param isTrusted   Whether the [actionUrl] passed the domain allowlist check.
      */
     fun showAnnouncementNotification(
         context: Context,
         title: String,
         body: String,
         actionLabel: String = "Open",
-        actionUrl: String = ""
+        actionUrl: String = "",
+        isTrusted: Boolean = true
     ) {
         createNotificationChannel(context)
 
@@ -213,17 +236,31 @@ object UpdateNotificationManager {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
+        // When the URL is from an untrusted domain, prepend a warning to the notification
+        // so the user is aware before tapping through.
+        val displayTitle: String
+        val displayBody: String
+
+        if (!isTrusted && actionUrl.isNotBlank()) {
+            val host = UrlAllowlistManager.extractHost(actionUrl)
+            displayTitle = "⚠️ $title"
+            displayBody = "Links to untrusted domain: $host\n\n$body"
+        } else {
+            displayTitle = title
+            displayBody = body
+        }
+
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_launcher_foreground)
-            .setContentTitle(title)
-            .setContentText(body)
-            .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+            .setContentTitle(displayTitle)
+            .setContentText(displayBody)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(displayBody))
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setAutoCancel(true)
             .setContentIntent(contentPendingIntent)
             .addAction(
                 R.drawable.ic_launcher_foreground,
-                actionLabel,
+                if (isTrusted || actionUrl.isBlank()) actionLabel else "Open Anyway",
                 actionPendingIntent
             )
             .addAction(

--- a/android/app/src/main/java/com/bunty/clipsync/UrlAllowlistManager.kt
+++ b/android/app/src/main/java/com/bunty/clipsync/UrlAllowlistManager.kt
@@ -1,0 +1,130 @@
+package com.bunty.clipsync
+
+import android.content.Context
+import android.net.Uri
+
+/**
+ * Manages a domain allowlist for URLs received via FCM push notifications.
+ *
+ * FCM data messages can carry `downloadUrl` (for app updates) and `actionUrl` (for
+ * announcements). If Firebase project credentials are ever compromised, an attacker
+ * could push notifications containing phishing links or malicious APK download URLs.
+ * This manager mitigates that risk by validating every incoming URL against a set of
+ * trusted domains before the app opens it in the browser.
+ *
+ * The allowlist is composed of two layers:
+ * 1. **Default domains** — hard-coded trusted domains that ship with the app and
+ *    cannot be removed by the user (e.g. the official GitHub releases page).
+ * 2. **User-added domains** — custom domains the user has chosen to trust, stored
+ *    in SharedPreferences and fully editable from the Settings screen.
+ *
+ * A URL is considered trusted when its host ends with (or exactly matches) any entry
+ * in the combined allowlist. For example, the default entry `"github.com"` trusts
+ * both `github.com` and any subdomain like `raw.githubusercontent.com` is NOT trusted
+ * — only exact suffix matches are accepted.
+ */
+object UrlAllowlistManager {
+
+    private const val PREFS_NAME = "url_allowlist_prefs"
+    private const val KEY_USER_DOMAINS = "user_domains"
+
+    /**
+     * Default trusted domains that ship with the app. These cannot be removed by the
+     * user and cover the official distribution channels for ClipSync.
+     */
+    val DEFAULT_DOMAINS: Set<String> = setOf(
+        "github.com",
+        "forms.gle",
+        "docs.google.com"
+    )
+
+    /**
+     * Returns the full set of trusted domains: defaults merged with any user-added entries.
+     */
+    fun getAllowedDomains(context: Context): Set<String> {
+        return DEFAULT_DOMAINS + getUserDomains(context)
+    }
+
+    /**
+     * Returns only the domains that the user has added manually.
+     */
+    fun getUserDomains(context: Context): Set<String> {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val raw = prefs.getString(KEY_USER_DOMAINS, "") ?: ""
+        if (raw.isBlank()) return emptySet()
+        return raw.split(",")
+            .map { it.trim().lowercase() }
+            .filter { it.isNotEmpty() }
+            .toSet()
+    }
+
+    /**
+     * Adds a user-specified domain to the allowlist.
+     *
+     * The domain is normalised to lowercase and trimmed before storage. Duplicates
+     * and entries that already appear in [DEFAULT_DOMAINS] are silently ignored.
+     *
+     * @param domain The domain to trust, e.g. `"example.com"`.
+     */
+    fun addUserDomain(context: Context, domain: String) {
+        val normalised = domain.trim().lowercase()
+        if (normalised.isEmpty()) return
+        val current = getUserDomains(context).toMutableSet()
+        current.add(normalised)
+        saveUserDomains(context, current)
+    }
+
+    /**
+     * Removes a user-specified domain from the allowlist.
+     *
+     * Default domains cannot be removed — attempting to do so is a no-op.
+     *
+     * @param domain The domain to remove.
+     */
+    fun removeUserDomain(context: Context, domain: String) {
+        val normalised = domain.trim().lowercase()
+        val current = getUserDomains(context).toMutableSet()
+        current.remove(normalised)
+        saveUserDomains(context, current)
+    }
+
+    /**
+     * Checks whether the given [url] belongs to a trusted domain.
+     *
+     * Returns `true` if the URL's host exactly matches or is a subdomain of any
+     * entry in the combined allowlist (defaults + user). Returns `false` for blank
+     * URLs, URLs without a parseable host, or hosts that do not match.
+     */
+    fun isUrlTrusted(context: Context, url: String): Boolean {
+        if (url.isBlank()) return true // No URL to open — nothing to validate.
+
+        val host = try {
+            Uri.parse(url).host?.lowercase()
+        } catch (_: Exception) {
+            null
+        } ?: return false
+
+        val allowedDomains = getAllowedDomains(context)
+        return allowedDomains.any { domain ->
+            host == domain || host.endsWith(".$domain")
+        }
+    }
+
+    /**
+     * Extracts the host from a URL for display in warning messages.
+     *
+     * @return The host portion of the URL, or the raw URL string if parsing fails.
+     */
+    fun extractHost(url: String): String {
+        return try {
+            Uri.parse(url).host ?: url
+        } catch (_: Exception) {
+            url
+        }
+    }
+
+    private fun saveUserDomains(context: Context, domains: Set<String>) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.edit().putString(KEY_USER_DOMAINS, domains.joinToString(",")).apply()
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `UrlAllowlistManager` with default trusted domains (`github.com`, `forms.gle`, `docs.google.com`) and user-customizable domain storage via SharedPreferences
- Validates `downloadUrl` and `actionUrl` from FCM push messages against the allowlist before opening them
- Shows warning notifications and in-app dialog warnings when URLs come from untrusted domains (user can still choose to proceed)
- Adds a "Trusted Domains" settings section in the Homescreen where users can view defaults and add/remove custom trusted domains

## Test plan
- [ ] Send an FCM push with `type=update` and a `downloadUrl` on a trusted domain (e.g. `github.com`) — notification should appear normally
- [ ] Send an FCM push with `type=update` and a `downloadUrl` on an untrusted domain — notification should show "⚠️ Update from untrusted source" warning
- [ ] Send an FCM push with `type=announcement` and an untrusted `actionUrl` — notification should show warning prefix
- [ ] Open the app with a pending untrusted update — in-app dialog should show amber warning text
- [ ] Navigate to Settings → Trusted Domains section — default domains should appear as blue chips
- [ ] Add a custom domain via the "Add Domain" button — it should appear as a green chip
- [ ] Remove a user-added domain by tapping the "×" — it should be removed
- [ ] Verify default domains cannot be removed (no × button shown)

Closes #13

🤖 Generated with [Claude Code](https://claude.ai/code)