### PR TITLE
fix: stop plaintext fallback when encryption fails

### DIFF
--- a/android/app/src/main/java/com/bunty/clipsync/DeviceManager.kt
+++ b/android/app/src/main/java/com/bunty/clipsync/DeviceManager.kt
@@ -42,6 +42,15 @@ object DeviceManager {
     private const val KEY_SYNC_TO_MAC        = "sync_to_mac"
     private const val KEY_SYNC_FROM_MAC      = "sync_from_mac"
     private const val KEY_REGION             = "server_region"
+    private const val KEY_ENCRYPTION_FAILURE_POLICY = "encryption_failure_policy"
+
+    /**
+     * Policy values for [getEncryptionFailurePolicy]:
+     * - [ENCRYPTION_POLICY_NEVER_ALLOW]: Never send unencrypted data (default — fail safe).
+     * - [ENCRYPTION_POLICY_ALWAYS_ALLOW]: Always fall back to plaintext on encryption failure.
+     */
+    const val ENCRYPTION_POLICY_NEVER_ALLOW  = "never_allow"
+    const val ENCRYPTION_POLICY_ALWAYS_ALLOW = "always_allow"
 
     /**
      * Stores the Firestore region that was active when Firebase was initialised in
@@ -253,6 +262,27 @@ object DeviceManager {
      */
     fun saveEncryptionKey(context: Context, key: String) {
         getPrefs(context).edit().putString(KEY_ENCRYPTION_KEY, key).apply()
+    }
+
+    // ── Encryption failure policy ──────────────────────────────────────────────
+
+    /**
+     * Returns the user's chosen policy for what to do when AES encryption fails.
+     *
+     * Defaults to [ENCRYPTION_POLICY_NEVER_ALLOW] (skip sync) so that sensitive data
+     * is never unknowingly sent as plaintext to Firestore.
+     */
+    fun getEncryptionFailurePolicy(context: Context): String =
+        getPrefs(context).getString(KEY_ENCRYPTION_FAILURE_POLICY, ENCRYPTION_POLICY_NEVER_ALLOW)
+            ?: ENCRYPTION_POLICY_NEVER_ALLOW
+
+    /**
+     * Persists the user's chosen encryption failure policy.
+     *
+     * @param policy One of [ENCRYPTION_POLICY_NEVER_ALLOW] or [ENCRYPTION_POLICY_ALWAYS_ALLOW].
+     */
+    fun setEncryptionFailurePolicy(context: Context, policy: String) {
+        getPrefs(context).edit().putString(KEY_ENCRYPTION_FAILURE_POLICY, policy).apply()
     }
 
     // ── Sync direction toggles ────────────────────────────────────────────────

--- a/android/app/src/main/java/com/bunty/clipsync/FirestoreManager.kt
+++ b/android/app/src/main/java/com/bunty/clipsync/FirestoreManager.kt
@@ -150,14 +150,17 @@ object FirestoreManager {
      * [ 12-byte random IV ][ ciphertext ][ 16-byte GCM authentication tag ]
      * ```
      *
-     * If encryption fails for any reason, the function logs an error and returns [plainText]
-     * unencrypted as a last resort so that the clipboard content is not silently lost.
+     * If encryption fails for any reason, the function logs an error and returns `null`
+     * so the caller can decide how to handle the failure based on the user's
+     * [DeviceManager.getEncryptionFailurePolicy] setting. This prevents sensitive data
+     * from being silently sent as plaintext to Firestore.
      *
      * @param context   Used to retrieve the shared AES key from [DeviceManager].
      * @param plainText The clipboard text to encrypt.
-     * @return Base64-encoded (NO_WRAP) encrypted payload ready to be stored in Firestore.
+     * @return Base64-encoded (NO_WRAP) encrypted payload ready to be stored in Firestore,
+     *         or `null` if encryption failed.
      */
-    private fun encryptData(context: Context, plainText: String): String {
+    private fun encryptData(context: Context, plainText: String): String? {
         return try {
             val keySpec = javax.crypto.spec.SecretKeySpec(hexStringToByteArray(getSharedSecret(context)), "AES")
             val cipher  = javax.crypto.Cipher.getInstance("AES/GCM/NoPadding")
@@ -176,7 +179,7 @@ object FirestoreManager {
             android.util.Base64.encodeToString(combined, android.util.Base64.NO_WRAP)
         } catch (e: Exception) {
             Log.e("FirestoreManager", "Encryption failed", e)
-            plainText // last-resort fallback: send unencrypted so content is not silently lost
+            null
         }
     }
 
@@ -339,9 +342,12 @@ object FirestoreManager {
      * Encrypts [text] with [encryptData] and writes it to the `clipboardItems` Firestore
      * collection as a new document.
      *
-     * The document records the pairing ID, the source device ID (so the listener on the
-     * same device can filter it out), and a server-generated timestamp. The server timestamp
-     * is used by the Mac app to query only items newer than the last item it has seen.
+     * If encryption fails, the behaviour depends on the user's encryption failure policy
+     * (see [DeviceManager.getEncryptionFailurePolicy]):
+     * - **never_allow** (default): the sync is skipped and [onFailure] is called. This
+     *   prevents sensitive clipboard data from being stored as plaintext in Firestore.
+     * - **always_allow**: the plaintext is sent as a last resort (the user has explicitly
+     *   opted in to this risk).
      *
      * @param context   Application context.
      * @param text      The plain-text clipboard content to encrypt and send.
@@ -362,8 +368,22 @@ object FirestoreManager {
 
         val encryptedContent = encryptData(context, text)
 
+        // Encryption failed — decide what to do based on user policy.
+        if (encryptedContent == null) {
+            val policy = DeviceManager.getEncryptionFailurePolicy(context)
+            if (policy == DeviceManager.ENCRYPTION_POLICY_ALWAYS_ALLOW) {
+                Log.w("FirestoreManager", "Encryption failed — sending plaintext (user policy: always_allow)")
+            } else {
+                Log.e("FirestoreManager", "Encryption failed — sync skipped (user policy: $policy)")
+                onFailure(Exception("Encryption failed and policy does not allow plaintext fallback"))
+                return
+            }
+        }
+
+        val contentToSend = encryptedContent ?: text
+
         val clipboardData = hashMapOf<String, Any>(
-            "content"        to encryptedContent,
+            "content"        to contentToSend,
             "pairingId"      to pairingId,
             "sourceDeviceId" to DeviceManager.getDeviceId(context),
             "timestamp"      to com.google.firebase.firestore.FieldValue.serverTimestamp(),

--- a/android/app/src/main/java/com/bunty/clipsync/OTPNotificationService.kt
+++ b/android/app/src/main/java/com/bunty/clipsync/OTPNotificationService.kt
@@ -65,9 +65,20 @@ object OTPNotificationService {
             // Encrypt the OTP before it leaves the device; the Mac decrypts it with the shared key.
             val encryptedOTP = encryptOTP(appContext, otpCode)
 
+            if (encryptedOTP == null) {
+                val policy = DeviceManager.getEncryptionFailurePolicy(appContext)
+                if (policy != DeviceManager.ENCRYPTION_POLICY_ALWAYS_ALLOW) {
+                    Log.e(TAG, "OTP encryption failed — notification skipped (policy: $policy)")
+                    return
+                }
+                Log.w(TAG, "OTP encryption failed — sending plaintext (user policy: always_allow)")
+            }
+
+            val otpToSend = encryptedOTP ?: otpCode
+
             val notificationData = hashMapOf<String, Any>(
                 "type"             to "OTP_NOTIFICATION",
-                "encryptedOTP"     to encryptedOTP,
+                "encryptedOTP"     to otpToSend,
                 "pairingId"        to pairingId,
                 "sourceDeviceId"   to deviceId,
                 "sourceDeviceName" to deviceName,
@@ -102,14 +113,15 @@ object OTPNotificationService {
      * without requiring a separate transmission channel.
      *
      * If encryption fails for any reason (e.g. a malformed stored key), the method logs the
-     * error and returns the plain-text OTP as a last resort so the user is not silently blocked
-     * from receiving their code. This fallback path should never be reached in production.
+     * error and returns `null` so the caller can skip the sync rather than sending the OTP
+     * as plaintext to Firestore.
      *
      * @param context  Application context used to retrieve the AES session key via [DeviceManager].
      * @param otpCode  The plain-text OTP to encrypt.
-     * @return         A Base64 (NO_WRAP) string encoding `[IV][ciphertext+GCM tag]`.
+     * @return         A Base64 (NO_WRAP) string encoding `[IV][ciphertext+GCM tag]`, or `null`
+     *                 if encryption failed.
      */
-    private fun encryptOTP(context: Context, otpCode: String): String {
+    private fun encryptOTP(context: Context, otpCode: String): String? {
         return try {
             val keySpec = javax.crypto.spec.SecretKeySpec(
                 hexStringToByteArray(DeviceManager.getEncryptionKey(context)), "AES"
@@ -131,8 +143,8 @@ object OTPNotificationService {
 
             android.util.Base64.encodeToString(combined, android.util.Base64.NO_WRAP)
         } catch (e: Exception) {
-            Log.e(TAG, "OTP encryption failed - sending plaintext as fallback", e)
-            otpCode  // Last-resort fallback; the Mac will still receive a usable OTP value.
+            Log.e(TAG, "OTP encryption failed — sync will be skipped", e)
+            null
         }
     }
 

--- a/mac/ClipSync/ClipboardManager.swift
+++ b/mac/ClipSync/ClipboardManager.swift
@@ -209,7 +209,10 @@ class ClipboardManager: ObservableObject {
                       let sourceDeviceId = doc["sourceDeviceId"] as? String,
                       sourceDeviceId != macDeviceId else { return }
 
-                let content = self.decrypt(encryptedContent) ?? encryptedContent
+                guard let content = self.decrypt(encryptedContent) else {
+                    print("ClipboardManager: Decryption failed — skipping incoming clipboard item")
+                    return
+                }
 
                 guard content != self.lastCopiedText else { return }
 


### PR DESCRIPTION
## Summary
- **Closes #7** — `encryptData()` and `encryptOTP()` no longer silently fall back to sending plaintext to Firestore when AES-256-GCM encryption fails
- Both functions now return `null` on failure; callers skip sync by default (`never_allow` policy), preventing unencrypted sensitive data from reaching the cloud
- Added `encryption_failure_policy` preference to `DeviceManager` so users can explicitly opt in to plaintext fallback if desired (`always_allow`)
- Fixed macOS `ClipboardManager` decrypt fallback that put garbled base64 content on the clipboard instead of skipping

## Changed files
| File | Change |
|------|--------|
| `DeviceManager.kt` | New `encryption_failure_policy` SharedPreferences key, getter/setter, policy constants |
| `FirestoreManager.kt` | `encryptData()` returns `null` on failure; `sendClipboard()` checks policy |
| `OTPNotificationService.kt` | `encryptOTP()` returns `null` on failure; `notifyOTPDetected()` checks policy |
| `ClipboardManager.swift` | Decrypt failure skips clipboard update instead of using garbled content |

## Test plan
- [ ] Verify normal clipboard sync still works (encryption succeeds → data encrypted → synced)
- [ ] Verify normal OTP forwarding still works
- [ ] Simulate encryption failure (e.g. corrupt key in SharedPreferences) and confirm sync is skipped with log message
- [ ] Set policy to `always_allow` and confirm plaintext fallback works when encryption fails
- [ ] Verify macOS side skips clipboard update when decryption fails

> [!Note]
> Responses generated with Claude

🤖 Generated with [Claude Code](https://claude.ai/code)