### PR TITLE
docs: publish reference Firestore rules + bring-your-own-Firebase guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,51 @@ ClipSync uses an Accessibility Service to detect copy events. On **Android 13+**
 
 ---
 
+## 🔧 Self-Hosting (Bring Your Own Firebase)
+
+ClipSync has no custom server — both apps relay through **Firebase Firestore**. You can point the apps at **your own Firebase project** for full control over your backend, access rules, and data residency. This is also required to build the apps from source.
+
+#### 1. Create a Firebase project
+In the [Firebase Console](https://console.firebase.google.com/), create a project and enable:
+- **Cloud Firestore**
+- **Authentication** → **Anonymous** sign-in provider
+- **Cloud Messaging** (for OTP/notification relay)
+
+#### 2. Add your Firebase config files
+These files are git-ignored, so each contributor supplies their own:
+- **Android:** download `google-services.json` → place in `android/app/`
+- **macOS:** download `GoogleService-Info.plist` → add to the `mac/ClipSync/` target
+
+#### 3. Fill in the config templates
+The repo ships `.example` templates. Copy each one (dropping the `.example` suffix) and fill in your values:
+
+```bash
+# Android
+cp android/app/src/main/java/com/bunty/clipsync/RegionConfig.kt.example \
+   android/app/src/main/java/com/bunty/clipsync/RegionConfig.kt
+cp android/app/src/main/java/com/bunty/clipsync/Secrets.kt.example \
+   android/app/src/main/java/com/bunty/clipsync/Secrets.kt
+
+# macOS
+cp mac/ClipSync/RegionConfig.swift.example mac/ClipSync/RegionConfig.swift
+```
+
+#### 4. Deploy the Firestore security rules
+A reference copy of the rules lives at [`firestore.rules.example`](firestore.rules.example). Copy and deploy it:
+
+```bash
+cp firestore.rules.example firestore.rules
+firebase deploy --only firestore:rules
+```
+
+### 🔒 Security note
+
+The Firestore rules are now **published and auditable** in [`firestore.rules.example`](firestore.rules.example). They require every request to carry a valid Firebase Auth token (anonymous auth is enough) and deny everything by default.
+
+> **Heads up:** the reference rules require authentication. The Android client already signs in anonymously on launch, but the macOS client does not yet authenticate. Deploy the auth-required rules only after the Mac client has been updated to sign in anonymously, otherwise the Mac app will lose Firestore access. See the comments in `firestore.rules.example` for details and planned per-pairing hardening.
+
+---
+
 ## 🤝 Contributing
 
 We love contributions!

--- a/firestore.rules.example
+++ b/firestore.rules.example
@@ -1,0 +1,78 @@
+// ClipSync — Reference Firestore Security Rules
+// ----------------------------------------------------------------------------
+// This is a REFERENCE copy of the access-control rules for the Firestore
+// collections ClipSync uses. It is published so contributors and self-hosters
+// can audit exactly how data access is controlled.
+//
+// Usage (self-hosting / bring-your-own-Firebase):
+//   1. Copy this file to `firestore.rules`:
+//        cp firestore.rules.example firestore.rules
+//   2. Deploy it to your own Firebase project:
+//        firebase deploy --only firestore:rules
+//
+// ----------------------------------------------------------------------------
+// IMPORTANT CAVEAT — read before deploying
+// ----------------------------------------------------------------------------
+// These rules require every request to carry a valid Firebase Auth token
+// (anonymous auth is sufficient). The Android client already signs in
+// anonymously on launch (see ClipSyncApp.kt -> signInAnonymously()).
+//
+// The macOS client does NOT yet authenticate — `FirebaseManager.isAuthenticated`
+// is currently a stub that returns `true`, and FirebaseAuth is not linked in the
+// Xcode project. If you deploy these auth-required rules while the Mac client is
+// still unauthenticated, the Mac app will lose all Firestore access (reads and
+// writes will be denied).
+//
+// Deploy these rules only AFTER the Mac client has been updated to sign in
+// anonymously (matching Android). Until then, the hosted backend has to allow
+// unauthenticated access, which is the underlying security limitation this file
+// is meant to help close.
+//
+// ----------------------------------------------------------------------------
+// FUTURE HARDENING (not implemented here)
+// ----------------------------------------------------------------------------
+// Anonymous auth alone proves "some app instance is signed in" — it does NOT
+// scope a user to their own pairing. With these rules, any signed-in client that
+// knows a `pairingId` could still read that pair's (encrypted) documents.
+//
+// True per-pairing isolation requires:
+//   - Recording both devices' auth UIDs on the pairing document at pair time
+//     (e.g. an `authorizedUids` array).
+//   - Stamping each clipboardItems / notifications document with its `pairingId`
+//     and validating the caller against the pairing's `authorizedUids`, e.g.:
+//         allow read, write: if request.auth.uid in
+//           get(/databases/$(database)/documents/pairings/$(resource.data.pairingId)).data.authorizedUids;
+// This is intentionally out of scope for this reference file.
+
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // Returns true when the request carries a valid Firebase Auth token.
+    // Anonymous auth satisfies this check.
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    // Device pairing records (Mac <-> Android link metadata).
+    match /pairings/{pairingId} {
+      allow read, write: if isSignedIn();
+    }
+
+    // Encrypted clipboard payloads relayed between paired devices.
+    match /clipboardItems/{itemId} {
+      allow read, write: if isSignedIn();
+    }
+
+    // Short-lived OTP / notification relay documents.
+    match /notifications/{notificationId} {
+      allow read, write: if isSignedIn();
+    }
+
+    // Default deny: anything not explicitly matched above is rejected.
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/mac/ClipSync/FirebaseManager.swift
+++ b/mac/ClipSync/FirebaseManager.swift
@@ -50,6 +50,11 @@ class FirebaseManager {
         return FirebaseApp.app() != nil
     }
 
+    // TODO: This is a stub — the Mac client does not yet sign in to Firebase Auth.
+    // The Android client authenticates anonymously on launch (see ClipSyncApp.kt ->
+    // signInAnonymously()), but no FirebaseAuth sign-in exists here. To enforce
+    // auth-required Firestore rules (see firestore.rules.example), link FirebaseAuth
+    // in the Xcode project, sign in anonymously, and return the real auth state here.
     var isAuthenticated: Bool {
         return true
     }


### PR DESCRIPTION
Addresses the "No visible Firebase Auth — Firestore rules are sole access control" issue.

### Finding
The issue states there's "no Firebase Auth anywhere," but it's actually an **asymmetry**:
- **Android already authenticates** — `ClipSyncApp.kt` calls `signInAnonymously()` and `firebase-auth-ktx` is a dependency.
- **The Mac client does not** — `FirebaseManager.isAuthenticated` is hardcoded to `return true`, and `FirebaseAuth` isn't linked in the Xcode project.

Because the Mac client is unauthenticated, the hosted Firestore rules are forced to be permissive — the real root of the concern.

### What this PR does (additive, no runtime behavior change)
- Adds `firestore.rules.example`: an **auditable** reference of the access rules (require-auth + deny-all) for self-hosters to review.
- Documents **Bring-Your-Own-Firebase** setup and rule deployment in the README, plus a Security note.
- Adds a clarifying `TODO` on the Mac `isAuthenticated` stub.

### Recommended follow-up (not in this PR)
- Add anonymous Firebase Auth to the macOS client to match Android, so auth-required rules can be deployed without breaking Mac sync.
- Longer term: per-pairing UID scoping in the pairing flow + rules.

I scoped this to docs + reference rules since I can't build/test the apps locally; the maintainer should validate/deploy the rules and add Mac auth before tightening enforcement.